### PR TITLE
build(deps): bump the patternfly group with 3 updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "5.2.0",
-    "@patternfly/react-core": "5.1.2",
-    "@patternfly/react-icons": "5.1.2",
-    "@patternfly/react-styles": "5.1.2",
+    "@patternfly/react-core": "5.2.0",
+    "@patternfly/react-icons": "5.2.0",
+    "@patternfly/react-styles": "5.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   }


### PR DESCRIPTION
Bumps the patternfly group with 3 updates: [@patternfly/react-core](https://github.com/patternfly/patternfly-react), [@patternfly/react-icons](https://github.com/patternfly/patternfly-react) and @patternfly/react-styles.


Updates `@patternfly/react-core` from 5.1.2 to 5.2.0
- [Release notes](https://github.com/patternfly/patternfly-react/releases)
- [Commits](https://github.com/patternfly/patternfly-react/compare/@patternfly/react-core@5.1.2...@patternfly/react-core@5.2.0)

Updates `@patternfly/react-icons` from 5.1.2 to 5.2.0
- [Release notes](https://github.com/patternfly/patternfly-react/releases)
- [Commits](https://github.com/patternfly/patternfly-react/compare/@patternfly/react-icons@5.1.2...@patternfly/react-icons@5.2.0)

Updates `@patternfly/react-styles` from 5.1.2 to 5.2.0

---
updated-dependencies:
- dependency-name: "@patternfly/react-core" dependency-type: direct:production update-type: version-update:semver-minor dependency-group: patternfly
- dependency-name: "@patternfly/react-icons" dependency-type: direct:production update-type: version-update:semver-minor dependency-group: patternfly
- dependency-name: "@patternfly/react-styles" dependency-type: direct:production update-type: version-update:semver-minor dependency-group: patternfly ...